### PR TITLE
Fix segfault on /locations when avidb_messages is empty

### DIFF
--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -3128,7 +3128,13 @@ Json::Value parse_locations(const std::string &producer, const EngineMetaData &e
           //
           auto it = edr_md->stationTemporalExtentMetaData.find(loc.id);
 
-          if (it != edr_md->stationTemporalExtentMetaData.end())
+          // Same UB-on-empty-vector shape as the avi 'all' feature block
+          // below: an entry today is only inserted when the station has at
+          // least one matching message, but defending against an empty
+          // time_periods makes the function robust to future refactors that
+          // might pre-populate the map.
+          if (it != edr_md->stationTemporalExtentMetaData.end() &&
+              !it->second.time_periods.empty())
           {
             start_time = it->second.time_periods.front().start_time;
             end_time = it->second.time_periods.back().end_time;

--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -3171,10 +3171,17 @@ Json::Value parse_locations(const std::string &producer, const EngineMetaData &e
       all["bbox"] = bbox;
 
       auto properties = Json::Value(Json::ValueType::objectValue);
-      auto start_time = edr_md->temporal_extent.single_time_periods.front().start_time;
-      auto end_time = edr_md->temporal_extent.single_time_periods.back().start_time;
-      properties["datetime"] = Json::Value(Fmi::to_iso_extended_string(start_time) + "Z/" +
-                                           Fmi::to_iso_extended_string(end_time) + "Z");
+      // single_time_periods is empty when no rows in avidb_messages match the
+      // collection's filters. Without this guard front()/back() on an empty
+      // vector is undefined behavior and crashes the server (SIGSEGV) on the
+      // /collections/<avi-collection>/locations endpoint.
+      if (!edr_md->temporal_extent.single_time_periods.empty())
+      {
+        auto start_time = edr_md->temporal_extent.single_time_periods.front().start_time;
+        auto end_time = edr_md->temporal_extent.single_time_periods.back().start_time;
+        properties["datetime"] = Json::Value(Fmi::to_iso_extended_string(start_time) + "Z/" +
+                                             Fmi::to_iso_extended_string(end_time) + "Z");
+      }
       properties["detail"] = "Id is special location";
       properties["name"] = "Special logical selector representing all collection locations";
       all["properties"] = properties;


### PR DESCRIPTION
## Summary
`parse_locations()` (`edr/CoverageJson.cpp`) builds a special "all" feature for AVI producers and reads `start_time`/`end_time` from `temporal_extent.single_time_periods.front()/back()`. That block is only gated on `!locations->empty()`, but `single_time_periods` can be empty independently — it is built from `avidb_messages` rows by `getAviTemporalExtent`, so any deployment with stations/collections configured but no actual messages yet hits an empty vector.

`front()` / `back()` on an empty `std::vector` is undefined behavior. In practice it segfaults (SIGSEGV / exit 139) — smartmetd's stack-trace handler does not catch raw SIGSEGV, so the only visible symptom is the upstream nginx reporting 502 with no log entry beyond `Received request: /edr/collections/<id>/locations`.

This PR:
1. Guards the `single_time_periods.front()/back()` lookup and omits the `datetime` property when no time periods are known, instead of crashing.
2. Adds a defensive `!empty()` guard to a second `time_periods.front()/back()` access in the same function (`stationTemporalExtentMetaData[loc.id]`), which has the same UB shape but is not reachable today (see audit below).

## Reproduction
- Configured collections, e.g.:
  ```
  avi:
  {
    period_length = 30;
    collections:
    (
      { name = "metar"; countries = ["EE"]; }
    );
  };
  ```
- `avidb_stations` populated for `EE`, `avidb_messages` empty.
- `GET /edr/collections/metar/locations` → SIGSEGV → 502 / CrashLoopBackOff.
- Insert one matching METAR row → request returns **200 OK** with a valid GeoJSON FeatureCollection (verified on `fmidev/smartmetserver:26.03.19`).

## Audit of every other `time_periods` / `single_time_periods` front/back/at access in the EDR plugin

To answer the natural follow-up question — "is this the only place?" — every front/back/at on these vectors was reviewed:

| Location | Access | Guard |
|---|---|---|
| `CoverageJson.cpp:69` | `time_periods.at(0)` | inside `else` of `if (time_periods.empty())` at L58 ✓ |
| `CoverageJson.cpp:131-135` | `time_periods.at(0)`, `at(sz-1)` | same outer `else` ✓ |
| `CoverageJson.cpp:1242-1250` | `time_periods.front()` and members | `if (!time_periods.empty())` at L1235 ✓ |
| `CoverageJson.cpp:3133-3134` | `it->second.time_periods.front()/back()` | only `if (it != end())`, no inner `!empty()` — **fixed defensively in commit 2** |
| `CoverageJson.cpp:3144-3148` | `time_periods.front()/back()` | `if (!time_periods.empty())` at L3101 ✓ |
| `CoverageJson.cpp:3174-3175` (BEFORE) | `single_time_periods.front()/back()` | only `if (!locations->empty())` — **the SIGSEGV, fixed in commit 1** |
| `EDRQueryParams.cpp:165-181` | `time_periods.front()/back()` | early-return at L154 if `time_periods.empty()` ✓ |
| `EDRQueryParams.cpp:160-161` | ternary on `single_time_periods.empty()` | falls back to `time_periods` (which by L154 is non-empty) ✓ |

So this PR closes the one observable SIGSEGV (commit 1) and the one matching theoretical UB (commit 2). All the other accesses are already correctly guarded.

### About commit 2 — is it currently reachable?

No. `stationTemporalExtentMetaData` (`EDRMetaData.cpp:719-738`) is only populated for stations that actually came back from `queryStationsAndMessages`. Those stations have at least one timestep, so the inner `time_periods` is always non-empty when the find() succeeds. The added `!empty()` check therefore costs nothing today and prevents the same UB pattern from reappearing if the population logic ever changes (e.g., pre-seeding entries from a separate source).

## Test plan
- [x] With empty `avidb_messages` and AVI collections configured, `/edr/collections/<id>/locations` no longer crashes; `all` feature is emitted without `datetime` (other features unchanged).
- [x] With ≥ 1 matching message, response is byte-identical to current behavior.
- [x] Code review of every other `time_periods` / `single_time_periods` access across the plugin (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)