### PR TITLE
Fix container access without checks

### DIFF
--- a/edr/AviEngineQuery.cpp
+++ b/edr/AviEngineQuery.cpp
@@ -217,7 +217,8 @@ void AviEngineQuery::processAviEngineQuery(const Config &config,
     const auto edrMetaData = edrProducerMetaData.find(producer);
     const auto &aviCollection = get_avi_collection(producer, config.getAviCollections());
 
-    if ((edrMetaData == edrProducerMetaData.end()) || aviCollection.getName().empty())
+    if ((edrMetaData == edrProducerMetaData.end()) || edrMetaData->second.empty() ||
+        aviCollection.getName().empty())
       throw Fmi::Exception(BCP, "Internal error: no metadata for producer " + producer, nullptr);
 
     SmartMet::Engine::Avi::QueryOptions queryOptions;

--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -539,7 +539,7 @@ Json::Value parameter_metadata(const EDRMetaData &metadata,
     if (it != custom_dim_refs.end())
     {
       standard_name_vocabulary = it->second;
-      if (standard_name_vocabulary.back() == '/')
+      if (!standard_name_vocabulary.empty() && standard_name_vocabulary.back() == '/')
         standard_name_vocabulary.pop_back();
     }
 

--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -3053,9 +3053,10 @@ Json::Value parse_locations(const std::string &producer, const EngineMetaData &e
     for (const auto &item : metadata)
     {
       const auto &engine_metadata = item.second;
-      if (engine_metadata.find(producer) != engine_metadata.end())
+      auto it = engine_metadata.find(producer);
+      if (it != engine_metadata.end() && !it->second.empty())
       {
-        edr_md = &engine_metadata.at(producer).front();
+        edr_md = &it->second.front();
         break;
       }
     }

--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -2765,7 +2765,7 @@ Json::Value format_output_data_vertical_profile(
   try
   {
     if (outputData.empty())
-      Json::Value();
+      return {};
 
     Json::Value coverageCollection;
 

--- a/edr/EDRMetaData.cpp
+++ b/edr/EDRMetaData.cpp
@@ -993,10 +993,11 @@ SupportedLocations get_supported_locations(const AviMetaData &amd,
 const Fmi::DateTime &get_latest_data_update_time(const EDRProducerMetaData &pmd,
                                                  const std::string &producer)
 {
-  if (pmd.find(producer) != pmd.end())
+  auto it = pmd.find(producer);
+  if (it != pmd.end() && !it->second.empty())
   {
     // Latest update time is same for all metadata instances of the same producer
-    return pmd.at(producer).front().latest_data_update_time;
+    return it->second.front().latest_data_update_time;
   }
   return NOT_A_DATE_TIME;
 }

--- a/edr/EDRQueryParams.cpp
+++ b/edr/EDRQueryParams.cpp
@@ -623,7 +623,8 @@ std::string EDRQueryParams::parsePosition(const std::string& coords)
       for (auto& coordinate_item : coordinates)
       {
         boost::algorithm::trim(coordinate_item);
-        if (coordinate_item.front() == '(' && coordinate_item.back() == ')')
+        if (coordinate_item.size() >= 2 && coordinate_item.front() == '(' &&
+            coordinate_item.back() == ')')
           coordinate_item = coordinate_item.substr(1, coordinate_item.length() - 2);
         std::vector<std::string> parts;
         boost::algorithm::split(parts, coordinate_item, boost::algorithm::is_any_of(" "));

--- a/edr/GeoJson.cpp
+++ b/edr/GeoJson.cpp
@@ -516,6 +516,8 @@ Json::Value format_output_data_one_point(const TS::OutputData &outputData,
     feature_collection["parameters"] =
         get_edr_series_parameters(query_parameters, emd, custom_dim_refs, language);
     auto coordinates = get_coordinates(outputData, query_parameters);
+    if (coordinates.empty())
+      return feature_collection;
     const auto &lon_precision = emd.getPrecision("longitude");
     const auto &lat_precision = emd.getPrecision("latitude");
     feature_collection["bbox"] = get_bbox(coordinates, lon_precision, lat_precision);

--- a/edr/GeoJson.cpp
+++ b/edr/GeoJson.cpp
@@ -249,7 +249,7 @@ Json::Value get_edr_series_parameters(const std::vector<Spine::Parameter> &query
     if (it != custom_dim_refs.end())
     {
       standard_name_vocabulary = it->second;
-      if (standard_name_vocabulary.back() == '/')
+      if (!standard_name_vocabulary.empty() && standard_name_vocabulary.back() == '/')
         standard_name_vocabulary.pop_back();
     }
 

--- a/edr/GeoJson.cpp
+++ b/edr/GeoJson.cpp
@@ -665,6 +665,9 @@ Json::Value format_output_data_position(const TS::OutputData &outputData,
     feature_collection["parameters"] =
         get_edr_series_parameters(query_parameters, emd, custom_dim_refs, language);
 
+    if (query_parameters.empty())
+      return feature_collection;
+
     const auto lon_precision = emd.getPrecision("longitude");
     const auto lat_precision = emd.getPrecision("latitude");
     auto level_precision = 0;
@@ -813,6 +816,9 @@ DataPerParameter get_data_per_parameter(const TS::OutputData &outputData,
     DataPerParameter dpp;
 
     //	  std::cout << "get_output_data_per_parameter" << std::endl;
+
+    if (query_parameters.empty())
+      return dpp;
 
     bool levels_present = !levels.empty();
 

--- a/edr/PluginImpl.cpp
+++ b/edr/PluginImpl.cpp
@@ -1554,8 +1554,9 @@ EDRMetaData PluginImpl::getProducerMetaData(const std::string& producer) const
   for (const auto& item : metadata->getMetaData())
   {
     const auto& engine_metadata = item.second;
-    if (engine_metadata.find(producer) != engine_metadata.end())
-      return engine_metadata.at(producer).front();
+    auto it = engine_metadata.find(producer);
+    if (it != engine_metadata.end() && !it->second.empty())
+      return it->second.front();
   }
 
   return empty_emd;

--- a/edr/QueryProcessingHub.cpp
+++ b/edr/QueryProcessingHub.cpp
@@ -635,7 +635,9 @@ std::shared_ptr<std::string> QueryProcessingHub::processQuery(
 
       bool process_qengine_query = true;
 #ifndef WITHOUT_AVI
-      std::string producerName = (producerMissing ? "" : masterquery.timeproducers.front().front());
+      std::string producerName;
+      if (!producerMissing && !masterquery.timeproducers.front().empty())
+        producerName = masterquery.timeproducers.front().front();
       if (itsAviEngineQuery.isAviProducer(producerName) && !thePlugin.itsConfig.aviEngineDisabled())
       {
         itsAviEngineQuery.processAviEngineQuery(
@@ -908,7 +910,9 @@ std::size_t QueryProcessingHub::hash_value(const State& state,
     bool producerMissing = masterquery.timeproducers.empty();
 
 #ifndef WITHOUT_AVI
-    std::string producerName = (producerMissing ? "" : masterquery.timeproducers.front().front());
+    std::string producerName;
+    if (!producerMissing && !masterquery.timeproducers.front().empty())
+      producerName = masterquery.timeproducers.front().front();
     if (itsAviEngineQuery.isAviProducer(producerName))
       return Fmi::bad_hash;
 #endif

--- a/edr/UtilityFunctions.cpp
+++ b/edr/UtilityFunctions.cpp
@@ -358,7 +358,7 @@ bool parseRangeListValue(std::string& valueStr,
       {
         // Repeating interval Rn/start/step
 
-        if (toupper(parts[0].front()) != 'R')
+        if (parts[0].empty() || toupper(parts[0].front()) != 'R')
           throw Fmi::Exception(BCP, "");
 
         parts[0].erase(parts[0].begin());


### PR DESCRIPTION
### Summary of fixed problems generated by Claude Opus 4.7:

Audit complete. Here's what I found searching for the same class of bug — unguarded .front() / .back() on potentially empty std::vector / std::list / std::string.

### Confirmed bugs
1. [edr/CoverageJson.cpp:2767-2768](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L2767-L2768) — broken empty check (missing return)


if (outputData.empty())
    Json::Value();              // ← discarded temporary; no early-return!
...
const auto &outdata = outputData.front().second;   // UB if empty
The if body is a no-op, so the front() at line 2780 can still hit an empty vector. Identical pattern to the PR #14 fix. Fix: return Json::Value();.

2. [edr/GeoJson.cpp:518-522](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L518-L522) — coordinates.front() not guarded


auto coordinates = get_coordinates(outputData, query_parameters);
...
auto lonlat = coordinates.front();   // UB if get_coordinates returned empty
get_coordinates can return empty (early returns at lines 165-171 in the same file). The sibling routine in CoverageJson at [edr/CoverageJson.cpp:1837](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L1837) guards with if (coordinates.empty()) return coverage; — GeoJson is missing that guard.

### Likely bugs (same shape as PR #14 — map lookup succeeds, vector inside may be empty)
3. engine_metadata.at(producer).front() — producer key present, vector may be empty:

[edr/CoverageJson.cpp:3058](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L3058) in parse_locations
[edr/EDRMetaData.cpp:999](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/EDRMetaData.cpp#L999) in get_latest_data_update_time
[edr/PluginImpl.cpp:1558](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/PluginImpl.cpp#L1558) in getProducerMetaData
EDRProducerMetaData is std::map<std::string, std::vector<EDRMetaData>>; nothing guarantees the inner vector is non-empty just because the key exists. Mirrors exactly the PR comment ("guards against future code changes that might pre-populate the map").

4. Empty-string back-access on map values:

[edr/CoverageJson.cpp:542](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L542) and [edr/GeoJson.cpp:252](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L252) — standard_name_vocabulary.back() == '/' is called right after standard_name_vocabulary = it->second; with no !empty() check. UB if config has an empty standard_name value.
### Lower-priority / theoretical
5. [edr/EDRQueryParams.cpp:626](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/EDRQueryParams.cpp#L626) — coordinate_item.front() / .back() after trim. Malformed WKT input like MULTIPOINT(1 2 3,,4 5 6) yields an empty coordinate_item. Reachable via bad user input.

6. [edr/UtilityFunctions.cpp:361](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/UtilityFunctions.cpp#L361) — parts[0].front() on a split component that can be empty (leading /).

7. [edr/AviEngineQuery.cpp:172](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/AviEngineQuery.cpp#L172) — edrMetaDataVector.front() with no empty check (caller at [edr/AviEngineQuery.cpp:226](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/AviEngineQuery.cpp#L226) only verifies the map lookup).

8. [edr/GeoJson.cpp:672](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L672), [edr/GeoJson.cpp:821](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L821) — query_parameters.back() with no empty check.

9. [edr/QueryProcessingHub.cpp:638](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/QueryProcessingHub.cpp#L638) and :911 — masterquery.timeproducers.front().front(). The outer-empty case is guarded via producerMissing, but if timeproducers.front() (an AreaProducers = std::list<std::string>) is empty, front() on the list is UB.

Recommendation
Items 1, 2, 3, 4 are the closest matches to PR #14 and worth fixing in the same pass — item 1 in particular is unambiguously broken code. Want me to draft the fixes?Audit complete. Here's what I found searching for the same class of bug — unguarded .front() / .back() on potentially empty std::vector / std::list / std::string.

Confirmed bugs
1. [edr/CoverageJson.cpp:2767-2768](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L2767-L2768) — broken empty check (missing return)


if (outputData.empty())
    Json::Value();              // ← discarded temporary; no early-return!
...
const auto &outdata = outputData.front().second;   // UB if empty
The if body is a no-op, so the front() at line 2780 can still hit an empty vector. Identical pattern to the PR #14 fix. Fix: return Json::Value();.

2. [edr/GeoJson.cpp:518-522](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L518-L522) — coordinates.front() not guarded


auto coordinates = get_coordinates(outputData, query_parameters);
...
auto lonlat = coordinates.front();   // UB if get_coordinates returned empty
get_coordinates can return empty (early returns at lines 165-171 in the same file). The sibling routine in CoverageJson at [edr/CoverageJson.cpp:1837](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L1837) guards with if (coordinates.empty()) return coverage; — GeoJson is missing that guard.

Likely bugs (same shape as PR #14 — map lookup succeeds, vector inside may be empty)
3. engine_metadata.at(producer).front() — producer key present, vector may be empty:

[edr/CoverageJson.cpp:3058](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L3058) in parse_locations
[edr/EDRMetaData.cpp:999](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/EDRMetaData.cpp#L999) in get_latest_data_update_time
[edr/PluginImpl.cpp:1558](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/PluginImpl.cpp#L1558) in getProducerMetaData
EDRProducerMetaData is std::map<std::string, std::vector<EDRMetaData>>; nothing guarantees the inner vector is non-empty just because the key exists. Mirrors exactly the PR comment ("guards against future code changes that might pre-populate the map").

4. Empty-string back-access on map values:

[edr/CoverageJson.cpp:542](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/CoverageJson.cpp#L542) and [edr/GeoJson.cpp:252](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L252) — standard_name_vocabulary.back() == '/' is called right after standard_name_vocabulary = it->second; with no !empty() check. UB if config has an empty standard_name value.
Lower-priority / theoretical
5. [edr/EDRQueryParams.cpp:626](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/EDRQueryParams.cpp#L626) — coordinate_item.front() / .back() after trim. Malformed WKT input like MULTIPOINT(1 2 3,,4 5 6) yields an empty coordinate_item. Reachable via bad user input.

6. [edr/UtilityFunctions.cpp:361](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/UtilityFunctions.cpp#L361) — parts[0].front() on a split component that can be empty (leading /).

7. [edr/AviEngineQuery.cpp:172](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/AviEngineQuery.cpp#L172) — edrMetaDataVector.front() with no empty check (caller at [edr/AviEngineQuery.cpp:226](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/AviEngineQuery.cpp#L226) only verifies the map lookup).

8. [edr/GeoJson.cpp:672](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L672), [edr/GeoJson.cpp:821](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/GeoJson.cpp#L821) — query_parameters.back() with no empty check.

9. [edr/QueryProcessingHub.cpp:638](vscode-webview://0nivc9kepgghma0i5ncu064qb5i6n40l25rmgcrd0kja3257fohp/edr/QueryProcessingHub.cpp#L638) and :911 — masterquery.timeproducers.front().front(). The outer-empty case is guarded via producerMissing, but if timeproducers.front() (an AreaProducers = std::list<std::string>) is empty, front() on the list is UB.

Recommendation
Items 1, 2, 3, 4 are the closest matches to PR #14 and worth fixing in the same pass — item 1 in particular is unambiguously broken code. Want me to draft the fixes?