### PR TITLE
getAviTemporalExtent: query both TAC and IWXXM to fix null temporal extents

### DIFF
--- a/edr/EDRMetaData.cpp
+++ b/edr/EDRMetaData.cpp
@@ -670,8 +670,6 @@ void getAviTemporalExtent(const Engine::Avi::Engine &aviEngine,
     //
     queryOptions.itsMessageTypes.push_back(boost::algorithm::to_upper_copy(message_type));
 
-    queryOptions.itsMessageFormat = TAC_FORMAT;
-
     // From config file avi.period_length (30 days default)
     auto now = Fmi::SecondClock::universal_time();
     auto start_of_period = (now - Fmi::Hours(aviCollection.getPeriodLength() * 24));
@@ -690,8 +688,6 @@ void getAviTemporalExtent(const Engine::Avi::Engine &aviEngine,
     queryOptions.itsMaxMessageStations = -1;
     queryOptions.itsMaxMessageRows = -1;
     queryOptions.itsTimeOptions.itsQueryValidRangeMessages = true;
-    // Finnish TAC METAR filtering (ignore messages not starting with 'METAR')
-    queryOptions.itsFilterMETARs = (queryOptions.itsMessageFormat == TAC_FORMAT);
     // Finnish SPECIs are ignored (https://jira.fmi.fi/browse/BRAINSTORM-2472)
     //
     // BRAINSTORM-3284: now configurable, defaults to true
@@ -708,37 +704,52 @@ void getAviTemporalExtent(const Engine::Avi::Engine &aviEngine,
     //
     queryOptions.itsTimeOptions.itsMessageTimeChecks = false;
 
-    auto aviData = aviEngine.queryStationsAndMessages(queryOptions);
-
+    // Query both TAC and IWXXM so temporal extent is populated for TAC-only
+    // (FMI), IWXXM-only (EE), or mixed deployments.  TAC is queried first;
+    // per-station extents prefer TAC via map::insert (no overwrite on duplicate
+    // key).  The global timestep set accumulates both.  Finnish METAR filtering
+    // is TAC-specific and must not be applied to the IWXXM query.
+    //
     // BRAINSTORM-3320
     //
     // Storing station's temporal extent too, varies e.g. for taf collection
     //
     std::set<Fmi::LocalDateTime> timesteps;
-    std::set<Fmi::LocalDateTime> stationTimesteps;
 
-    for (auto stationId : aviData.itsStationIds)
+    auto processAviData = [&](SmartMet::Engine::Avi::QueryResult &aviData)
     {
-      auto icaoIter = aviData.itsValues[stationId]["icao"].cbegin();
-      auto icao = std::get<std::string>(*icaoIter);
-      auto timeIter = aviData.itsValues[stationId]["messagetime"].cbegin();
-      auto endIter = aviData.itsValues[stationId]["messagetime"].cend();
-
-      while (timeIter != endIter)
+      for (auto stationId : aviData.itsStationIds)
       {
-        Fmi::LocalDateTime timestep = std::get<Fmi::LocalDateTime>(*timeIter);
+        auto icaoIter = aviData.itsValues[stationId]["icao"].cbegin();
+        auto icao = std::get<std::string>(*icaoIter);
+        auto timeIter = aviData.itsValues[stationId]["messagetime"].cbegin();
+        auto endIter = aviData.itsValues[stationId]["messagetime"].cend();
 
-        timesteps.insert(timestep);
-        stationTimesteps.insert(timestep);
+        std::set<Fmi::LocalDateTime> stationTimesteps;
+        while (timeIter != endIter)
+        {
+          Fmi::LocalDateTime timestep = std::get<Fmi::LocalDateTime>(*timeIter);
 
-        timeIter++;
+          timesteps.insert(timestep);
+          stationTimesteps.insert(timestep);
+
+          timeIter++;
+        }
+
+        edrMetaData.stationTemporalExtentMetaData.insert(
+            make_pair(icao, get_temporal_extent(stationTimesteps)));
       }
+    };
 
-      auto temporal_extent = get_temporal_extent(stationTimesteps);
-      edrMetaData.stationTemporalExtentMetaData.insert(make_pair(icao, temporal_extent));
+    queryOptions.itsMessageFormat = TAC_FORMAT;
+    queryOptions.itsFilterMETARs = true;  // Finnish TAC METAR filtering (ignore messages not starting with 'METAR')
+    auto tacData = aviEngine.queryStationsAndMessages(queryOptions);
+    processAviData(tacData);
 
-      stationTimesteps.clear();
-    }
+    queryOptions.itsMessageFormat = IWXXM_FORMAT;
+    queryOptions.itsFilterMETARs = false;
+    auto iwxxmData = aviEngine.queryStationsAndMessages(queryOptions);
+    processAviData(iwxxmData);
 
     edrMetaData.temporal_extent = get_temporal_extent(timesteps);
 

--- a/edr/EDRMetaData.cpp
+++ b/edr/EDRMetaData.cpp
@@ -742,7 +742,8 @@ void getAviTemporalExtent(const Engine::Avi::Engine &aviEngine,
     };
 
     queryOptions.itsMessageFormat = TAC_FORMAT;
-    queryOptions.itsFilterMETARs = true;  // Finnish TAC METAR filtering (ignore messages not starting with 'METAR')
+    // itsFilterMETARs defaults to true; the engine gates the LIKE 'METAR%' predicate on the
+    // message type, so it does not incorrectly filter TAF or SIGMET collections.
     auto tacData = aviEngine.queryStationsAndMessages(queryOptions);
     processAviData(tacData);
 

--- a/edr/EDRMetaData.cpp
+++ b/edr/EDRMetaData.cpp
@@ -716,7 +716,7 @@ void getAviTemporalExtent(const Engine::Avi::Engine &aviEngine,
     //
     std::set<Fmi::LocalDateTime> timesteps;
 
-    auto processAviData = [&](SmartMet::Engine::Avi::QueryResult &aviData)
+    auto processAviData = [&](SmartMet::Engine::Avi::StationQueryData &aviData)
     {
       for (auto stationId : aviData.itsStationIds)
       {


### PR DESCRIPTION
## Problem

`getAviTemporalExtent` was hardcoded to query only `TAC_FORMAT`. The avi engine translates this to a SQL JOIN condition (`mf.name = 'TAC'`), so deployments that ingest messages exclusively in IWXXM format receive zero rows back. The result is an `edr_temporal_extent` with empty `time_periods` and `single_time_periods`.

This manifests as two observable failures:

1. **`/edr/collections` shows `"interval": [null, null]`** for all AVI collections even when `avidb_messages` is fully populated.
2. **`/edr/collections/<name>/locations` crashes** (SIGSEGV, exit 139) on binaries predating PR #14, because `parse_locations` calls `single_time_periods.front()`/`back()` without an empty-check guard. The crash appears in the `DateTime` copy constructor with source pointer `rsi = 0x0`, which is exactly what an empty-vector `front()` produces.

The crash was diagnosed from 30 core dumps (each ~660 MB) on an Estonian SWIM aviation deployment that stores all METAR/TAF/SIGMET in IWXXM format. All 30 dumps show the same stack: `DateTime::DateTime(const DateTime&)` ← `parseEDRMetaData` ← `processMetaDataQuery`.

## Root cause

`EDRMetaData.cpp:673` (before this PR):

```cpp
queryOptions.itsMessageFormat = TAC_FORMAT;
```

With zero TAC rows in the database, `aviData.itsStationIds` is empty, the accumulation loop never runs, `timesteps` stays empty, and `get_temporal_extent({})` returns an `edr_temporal_extent` with all vectors empty.

## Fix

Run the metadata query **twice** — once for TAC, once for IWXXM — and merge both result sets into a single timestep accumulator.

**Backward-compatibility for FMI (TAC-dominant):**
- The TAC query runs first and fills `stationTemporalExtentMetaData` via `map::insert`.
- The IWXXM `insert` for the same ICAO is a no-op (map does not overwrite on duplicate key), so TAC wins for per-station extents — no change in behaviour for existing TAC deployments.
- The global timestep `std::set` accumulates both. Duplicate timestamps from a station present in both formats are silently deduplicated by the set.

**For IWXXM-only deployments:**
- The TAC query returns empty; `processAviData(tacData)` is a no-op.
- The IWXXM query finds all stations and builds correct temporal extents.

**Finnish METAR filtering (`itsFilterMETARs`):**
- Set to `true` for the TAC query (same as the original hardcoded behaviour).
- Set to `false` for the IWXXM query — the filter rejects TAC messages that don't start with `"METAR"`, which is not applicable to IWXXM.

**NULL `valid_from`/`valid_to` in METAR messages:**
The avi engine SQL has explicit `IS NULL` fallback handling for both validity columns (EngineImpl.cpp:1334–1346, 1507–1519), so IWXXM METARs that carry no explicit validity period are returned and contribute to temporal extent normally.

**Cleanup:** `stationTimesteps` is now a local variable scoped to each station's loop body, eliminating the previous pattern of declaring it in the outer scope and manually clearing it between iterations.

## Testing notes

- **IWXXM-only (EE):** Before this fix, `GET /edr/collections/metar/locations` → 502 / SIGSEGV. After: returns a valid GeoJSON FeatureCollection with per-station `datetime` properties populated.
- **TAC-only (FMI):** IWXXM query returns empty; `processAviData(iwxxmData)` is a no-op. Behaviour identical to before.
- **Regression check:** Verify `/edr/collections` shows non-null `interval` values for all AVI collections after at least one matching message exists in each format.

## Relation to PR #14

PR #14 added empty-check guards in `parse_locations` that prevent the SIGSEGV. This PR addresses the underlying cause (why `time_periods` is empty in the first place) so that temporal extents are actually populated for IWXXM deployments, not just crash-safe when empty.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)