### PR TITLE
Fix std::bad_variant_access for area queries with vertical levels

### DIFF
--- a/edr/CoverageJson.cpp
+++ b/edr/CoverageJson.cpp
@@ -51,6 +51,84 @@ std::string parse_parameter_name(const std::string &name)
   return parameter_name;
 }
 
+// Grid engine parameters carry the level in the last field of the parameter name
+// (<param>:<producer>[:<geometry>[:<levelid>]][:<level>]) and each level of a parameter is
+// fetched as a separate parameter. The level of such a column can only be told from its name,
+// the separate 'level' column has no per parameter values.
+std::optional<double> parse_parameter_level(const std::string &name, const std::set<int> &levels)
+{
+  auto pos = name.rfind(':');
+  if (pos == std::string::npos || (pos + 1) >= name.size())
+    return {};
+
+  try
+  {
+    auto level = Fmi::stod(name.substr(pos + 1));
+
+    // The name has no level if the last field is something else (e.g. the level type identifier)
+    if (levels.find(static_cast<int>(level)) == levels.end())
+      return {};
+
+    return level;
+  }
+  catch (...)
+  {
+    return {};
+  }
+}
+
+// Data of location independent parameters (e.g. the grid engine 'level' column) is returned as
+// a plain time series even when the other columns of the same query are per coordinate groups.
+// Such a column is handled as a group having data for the first coordinate only.
+TS::TimeSeriesGroupPtr as_timeseries_group(const TS::TimeSeriesData &tsdata)
+{
+  if (const auto *ptr = std::get_if<TS::TimeSeriesGroupPtr>(&tsdata))
+    return *ptr;
+
+  if (const auto *ptr = std::get_if<TS::TimeSeriesPtr>(&tsdata))
+  {
+    auto tsg = std::make_shared<TS::TimeSeriesGroup>();
+    if (*ptr)
+      tsg->emplace_back(TS::LonLatTimeSeries(TS::LonLat(0, 0), **ptr));
+    return tsg;
+  }
+
+  return nullptr;
+}
+
+// The counterpart of as_timeseries_group: data of a coordinate group is handled as a plain
+// time series by using the data of the first coordinate.
+TS::TimeSeriesPtr as_timeseries(const TS::TimeSeriesData &tsdata)
+{
+  if (const auto *ptr = std::get_if<TS::TimeSeriesPtr>(&tsdata))
+    return *ptr;
+
+  if (const auto *ptr = std::get_if<TS::TimeSeriesGroupPtr>(&tsdata))
+  {
+    if (!*ptr || (*ptr)->empty())
+      return nullptr;
+
+    return std::make_shared<TS::TimeSeries>((*ptr)->front().timeseries);
+  }
+
+  return nullptr;
+}
+
+// Longitude, latitude and level are queried as the last parameters, thus the columns and the
+// query parameters must be in sync for the coordinates and levels to be taken from the
+// correct columns
+void check_column_count(const std::vector<TS::TimeSeriesData> &outdata,
+                        const std::vector<Spine::Parameter> &query_parameters)
+{
+  if (outdata.size() == query_parameters.size())
+    return;
+
+  Fmi::Exception exception(BCP, "Number of data columns does not match the number of parameters!");
+  exception.addParameter("Columns", Fmi::to_string(outdata.size()));
+  exception.addParameter("Parameters", Fmi::to_string(query_parameters.size()));
+  throw exception;
+}
+
 Json::Value parse_temporal_extent(const edr_temporal_extent &temporal_extent)
 {
   Json::Value nullvalue;
@@ -1775,10 +1853,12 @@ void process_parameters_one_point(const std::vector<TS::TimeSeriesData> &outdata
         continue;
 
       auto json_param_object = Json::Value(Json::ValueType::objectValue);
-      auto tsdata = outdata.at(j);
       auto values = Json::Value(Json::ValueType::arrayValue);
 
-      TS::TimeSeriesPtr ts = std::get<TS::TimeSeriesPtr>(tsdata);
+      TS::TimeSeriesPtr ts = as_timeseries(outdata.at(j));
+      if (!ts)
+        continue;
+
       if (i == 0)
       {
         coverage = add_prologue_one_point(level,
@@ -2480,9 +2560,14 @@ double get_level(const TS::TimeSeriesGroupPtr &tsg_level,
   {
     double level = std::numeric_limits<double>::max();
 
-    if (levels_present)
+    if (levels_present && tsg_level && !tsg_level->empty())
     {
-      const auto &llts_level = tsg_level->at(tsg_index);
+      // Location independent level data has values for the first coordinate only
+      const auto &llts_level = tsg_level->at(tsg_index < tsg_level->size() ? tsg_index : 0);
+
+      if (llts_index >= llts_level.timeseries.size())
+        return level;
+
       const auto &level_value = llts_level.timeseries.at(llts_index);
       if (const auto *ptr = std::get_if<double>(&level_value.value))
       {
@@ -2508,6 +2593,7 @@ void add_time_coord_value(const TS::LonLatTimeSeries &llts_data,
                           const TS::TimeSeriesGroupPtr &tsg_level,
                           const unsigned int tsg_index,
                           const bool &levels_present,
+                          const std::optional<double> &parameter_level,
                           unsigned int &levels_index,
                           const CoordinateFilter &coordinate_filter,
                           DataPerLevel &dpl)
@@ -2525,7 +2611,8 @@ void add_time_coord_value(const TS::LonLatTimeSeries &llts_data,
       tcv.lat = as_double(lat_value.value);
       tcv.time = (Fmi::date_time::to_iso_extended_string(data_value.time.utc_time()) + "Z");
 
-      double level = get_level(tsg_level, levels_present, tsg_index, lev_idx);
+      double level = (parameter_level ? *parameter_level
+                                      : get_level(tsg_level, levels_present, tsg_index, lev_idx));
 
       if (data_value.value != TS::None())
         tcv.value = data_value.value;
@@ -2534,7 +2621,7 @@ void add_time_coord_value(const TS::LonLatTimeSeries &llts_data,
       if (accept)
         dpl[level].push_back(tcv);
 
-      if (levels_present)
+      if (levels_present && tsg_level && !tsg_level->empty())
       {
         levels_index++;
         if (levels_index >= tsg_level->size())
@@ -2553,6 +2640,7 @@ DataPerLevel get_data_per_level(const TS::TimeSeriesGroupPtr &tsg_data,
                                 const TS::TimeSeriesGroupPtr &tsg_lat,
                                 const TS::TimeSeriesGroupPtr &tsg_level,
                                 const bool &levels_present,
+                                const std::optional<double> &parameter_level,
                                 const CoordinateFilter &coordinate_filter)
 {
   try
@@ -2560,7 +2648,10 @@ DataPerLevel get_data_per_level(const TS::TimeSeriesGroupPtr &tsg_data,
     DataPerLevel dpl;
 
     unsigned int levels_index = 0;
-    for (unsigned int k = 0; k < tsg_data->size(); k++)
+    // Location independent data has values for the first coordinate only
+    auto coordinate_count = std::min(tsg_data->size(), std::min(tsg_lon->size(), tsg_lat->size()));
+
+    for (unsigned int k = 0; k < coordinate_count; k++)
     {
       const auto &llts_data = tsg_data->at(k);
       const auto &llts_lon = tsg_lon->at(k);
@@ -2572,6 +2663,7 @@ DataPerLevel get_data_per_level(const TS::TimeSeriesGroupPtr &tsg_data,
                            tsg_level,
                            k,
                            levels_present,
+                           parameter_level,
                            levels_index,
                            coordinate_filter,
                            dpl);
@@ -2590,12 +2682,16 @@ void process_parameter_data(const std::vector<TS::TimeSeriesData> &outdata,
                             const unsigned int &level_index,
                             const CoordinateFilter &coordinate_filter,
                             const std::vector<Spine::Parameter> &query_parameters,
+                            const std::set<int> &levels,
                             const bool &levels_present,
+                            bool isGridProducer,
                             DataPerParameter &dpp,
                             ParameterNames &dpn)
 {
   try
   {
+    check_column_count(outdata, query_parameters);
+
     for (unsigned int j = 0; j < outdata.size(); j++)
     {
       auto parameter_name = parse_parameter_name(query_parameters[j].name());
@@ -2604,22 +2700,43 @@ void process_parameter_data(const std::vector<TS::TimeSeriesData> &outdata,
       if (lon_lat_level_param(parameter_name))
         continue;
 
-      auto tsdata = outdata.at(j);
-      auto tslon = outdata.at(longitude_index);
-      auto tslat = outdata.at(latitude_index);
-      TS::TimeSeriesGroupPtr tsg_data = std::get<TS::TimeSeriesGroupPtr>(tsdata);
-      TS::TimeSeriesGroupPtr tsg_lon = std::get<TS::TimeSeriesGroupPtr>(tslon);
-      TS::TimeSeriesGroupPtr tsg_lat = std::get<TS::TimeSeriesGroupPtr>(tslat);
+      TS::TimeSeriesGroupPtr tsg_data = as_timeseries_group(outdata.at(j));
+      TS::TimeSeriesGroupPtr tsg_lon = as_timeseries_group(outdata.at(longitude_index));
+      TS::TimeSeriesGroupPtr tsg_lat = as_timeseries_group(outdata.at(latitude_index));
+
+      if (!tsg_data || !tsg_lon || !tsg_lat)
+        continue;
+
       TS::TimeSeriesGroupPtr tsg_level = nullptr;
+      std::optional<double> parameter_level;
       if (levels_present)
       {
-        auto tslevel = outdata.at(level_index);
-        tsg_level = std::get<TS::TimeSeriesGroupPtr>(tslevel);
+        // Grid engine fetches each level of a parameter as a separate parameter, the level of
+        // the column is known from the parameter name only
+        if (isGridProducer)
+          parameter_level = parse_parameter_level(query_parameters[j].name(), levels);
+
+        if (!parameter_level)
+          tsg_level = as_timeseries_group(outdata.at(level_index));
       }
 
-      DataPerLevel dpl = get_data_per_level(
-          tsg_data, tsg_lon, tsg_lat, tsg_level, levels_present, coordinate_filter);
-      dpp[parameter_name] = dpl;
+      DataPerLevel dpl = get_data_per_level(tsg_data,
+                                            tsg_lon,
+                                            tsg_lat,
+                                            tsg_level,
+                                            levels_present,
+                                            parameter_level,
+                                            coordinate_filter);
+
+      // Data of a parameter can be collected from several columns (levels of a grid producer
+      // parameter) and from several locations, thus merge instead of replace
+      auto &parameter_data = dpp[parameter_name];
+      for (auto &dpl_item : dpl)
+      {
+        auto &values = parameter_data[dpl_item.first];
+        values.insert(values.end(), dpl_item.second.begin(), dpl_item.second.end());
+      }
+
       dpn[parameter_name] = parse_parameter_name(query_parameters[j].originalName());
     }
   }
@@ -2633,6 +2750,7 @@ DataPerParameter get_data_per_parameter(const TS::OutputData &outputData,
                                         const std::set<int> &levels,
                                         const CoordinateFilter &coordinate_filter,
                                         const std::vector<Spine::Parameter> &query_parameters,
+                                        bool isGridProducer,
                                         ParameterNames &dpn)
 {
   try
@@ -2674,7 +2792,9 @@ DataPerParameter get_data_per_parameter(const TS::OutputData &outputData,
                              level_index,
                              coordinate_filter,
                              query_parameters,
+                             levels,
                              levels_present,
+                             isGridProducer,
                              dpp,
                              dpn);
     }
@@ -2702,7 +2822,8 @@ Json::Value format_output_data_coverage_collection(
       Json::Value();
 
     ParameterNames dpn;
-    auto dpp = get_data_per_parameter(outputData, levels, coordinate_filter, query_parameters, dpn);
+    auto dpp = get_data_per_parameter(
+        outputData, levels, coordinate_filter, query_parameters, emd.isGridProducer(), dpn);
 
     if (query_type == EDRQueryType::Trajectory)
       return format_coverage_collection_trajectory(
@@ -2735,11 +2856,11 @@ void add_parameter(const std::string &parameter_name,
     for (unsigned int k = 0; k < ts_data->size(); k++)
     {
       const auto &data_value = ts_data->at(k);
-      const auto &level_value = ts_level->at(k);
       add_value(data_value, values_array, data_type_data, data_index, parameter_precision);
-      // All parameters have the same levels
-      if (firstParameter)
-        add_value(level_value, level_values, data_type_level, data_index, level_precision);
+      // All parameters have the same levels. Level data is missing for example when the level
+      // column has values for the first coordinate only (grid producers)
+      if (firstParameter && ts_level && (k < ts_level->size()))
+        add_value(ts_level->at(k), level_values, data_type_level, data_index, level_precision);
       if (parameter_data_type.find(parameter_name) == parameter_data_type.end())
         parameter_data_type[parameter_name] = data_type_data;
       data_index++;
@@ -2779,6 +2900,8 @@ Json::Value format_output_data_vertical_profile(
     // Only one position
     const auto &outdata = outputData.front().second;
 
+    check_column_count(outdata, query_parameters);
+
     std::map<std::string, Json::Value> parameter_data_values;
     std::map<std::string, Json::Value> parameter_data_type;
     //	std::map<std::string, Json::Value> parameter_level_values;
@@ -2798,10 +2921,11 @@ Json::Value format_output_data_vertical_profile(
 
       auto firstParameter = prev_param.empty();
       auto resetDataIndex = ((!firstParameter) && (!isGridProducer));
-      auto tsdata = outdata.at(j);
-      auto tslevel = outdata.at(level_index);
-      TS::TimeSeriesPtr ts_data = std::get<TS::TimeSeriesPtr>(tsdata);
-      TS::TimeSeriesPtr ts_level = std::get<TS::TimeSeriesPtr>(tslevel);
+      TS::TimeSeriesPtr ts_data = as_timeseries(outdata.at(j));
+      TS::TimeSeriesPtr ts_level = as_timeseries(outdata.at(level_index));
+
+      if (!ts_data)
+        continue;
 
       parameter_name = parse_parameter_name(query_parameters[j].originalName());
 
@@ -2863,10 +2987,12 @@ Json::Value format_output_data_vertical_profile(
     auto axis_names = Json::Value(Json::ValueType::arrayValue);
     axis_names[0] = Json::Value("z");
 
-    auto tslon = outdata.at(longitude_index);
-    auto tslat = outdata.at(latitude_index);
-    TS::TimeSeriesPtr ts_lon = std::get<TS::TimeSeriesPtr>(tslon);
-    TS::TimeSeriesPtr ts_lat = std::get<TS::TimeSeriesPtr>(tslat);
+    TS::TimeSeriesPtr ts_lon = as_timeseries(outdata.at(longitude_index));
+    TS::TimeSeriesPtr ts_lat = as_timeseries(outdata.at(latitude_index));
+
+    if (!ts_lon || !ts_lat || ts_lon->empty() || ts_lat->empty())
+      throw Fmi::Exception(BCP, "Coordinate data is missing!");
+
     // Only one position, timestep
     const auto &lon_timed_value = ts_lon->front();
     const auto &lat_timed_value = ts_lat->front();
@@ -3232,25 +3358,6 @@ Json::Value formatOutputData(const TS::OutputData &outputData,
 
     const auto &tsdata_first = outdata_first.at(0);
 
-    if (std::get_if<TS::TimeSeriesPtr>(&tsdata_first))
-    {
-      // Zero or one levels
-      if (levels.size() <= 1)
-      {
-        std::optional<int> level;
-        if (levels.size() == 1)
-          level = *(levels.begin());
-        return format_output_data_one_point(
-            outputData, emd, level, query_parameters, custom_dim_refs, language);
-      }
-
-      // More than one level
-      return format_output_data_vertical_profile(
-          outputData, emd, levels, coordinate_filter, query_parameters, query_type, useDataLevels,
-          custom_dim_refs, language);
-      //      return format_output_data_position(outputData, emd, query_parameters);
-    }
-
     if (const auto *ptr = std::get_if<TS::TimeSeriesVectorPtr>(&tsdata_first))
     {
       if (outdata_first.size() > 1)
@@ -3280,11 +3387,44 @@ Json::Value formatOutputData(const TS::OutputData &outputData,
           custom_dim_refs, language);
     }
 
-    if (std::get_if<TS::TimeSeriesGroupPtr>(&tsdata_first))
+    // Data of some of the parameters can be returned as a plain time series even when the query
+    // covers several coordinates (location independent parameters, the 'level' column of grid
+    // producers, ...), thus all the columns must be checked to know whether the result contains
+    // data for several coordinates or not
+    bool coordinate_groups = false;
+    for (const auto &tsdata : outdata_first)
+    {
+      if (std::get_if<TS::TimeSeriesGroupPtr>(&tsdata))
+      {
+        coordinate_groups = true;
+        break;
+      }
+    }
+
+    if (coordinate_groups)
     {
       return format_output_data_coverage_collection(
           outputData, emd, levels, coordinate_filter, query_parameters, query_type,
           custom_dim_refs, language);
+    }
+
+    if (std::get_if<TS::TimeSeriesPtr>(&tsdata_first))
+    {
+      // Zero or one levels
+      if (levels.size() <= 1)
+      {
+        std::optional<int> level;
+        if (levels.size() == 1)
+          level = *(levels.begin());
+        return format_output_data_one_point(
+            outputData, emd, level, query_parameters, custom_dim_refs, language);
+      }
+
+      // More than one level
+      return format_output_data_vertical_profile(
+          outputData, emd, levels, coordinate_filter, query_parameters, query_type, useDataLevels,
+          custom_dim_refs, language);
+      //      return format_output_data_position(outputData, emd, query_parameters);
     }
 
     return empty_result;

--- a/test/base/input/ecmwf_skandinavia_painepinta_area_z_list.get
+++ b/test/base/input/ecmwf_skandinavia_painepinta_area_z_list.get
@@ -1,0 +1,2 @@
+GET /edr/collections/ecmwf_skandinavia_painepinta/area?coords=POLYGON((23.5+60.0,23.5+62.0,25.0+62.0,25.0+60.0,23.5+60.0))&datetime=200809091200&z=500,850&parameter-name=Temperature HTTP/1.0
+

--- a/test/base/output/ecmwf_skandinavia_painepinta_area_z_list.get
+++ b/test/base/output/ecmwf_skandinavia_painepinta_area_z_list.get
@@ -1,0 +1,1872 @@
+{
+	"coverages" : 
+	[
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.15677
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.04250
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.85262
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.01511
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-12.9
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.50369
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.42452
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.9
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.20957
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.40103
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.6
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.91417
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.37325
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.3
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.54882
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.78396
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-14.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.26373
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.76013
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.8
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.97731
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.73194
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.5
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.59512
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.14397
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-14.0
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.31929
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.11979
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.8
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.64265
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.50455
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.9
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.37632
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.48001
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.8
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.69144
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.86568
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-14.0
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.43488
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.84077
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							500
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						-13.7
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.15677
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.04250
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						5.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.85262
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.01511
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						5.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.50369
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.42452
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.20957
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.40103
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.5
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.91417
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.37325
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.7
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.54882
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.78396
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.26373
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.76013
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.1
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.97731
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							60.73194
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						4.2
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.59512
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.14397
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						3.9
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.31929
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.11979
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						3.8
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.64265
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.50455
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						3.4
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.37632
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.48001
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						3.2
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							23.69144
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.86568
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						2.9
+					]
+				}
+			}
+		},
+		{
+			"type" : "Coverage",
+			"domain" : 
+			{
+				"type" : "Domain",
+				"axes" : 
+				{
+					"t" : 
+					{
+						"values" : 
+						[
+							"2008-09-09T09:00:00Z"
+						]
+					},
+					"x" : 
+					{
+						"values" : 
+						[
+							24.43488
+						]
+					},
+					"y" : 
+					{
+						"values" : 
+						[
+							61.84077
+						]
+					},
+					"z" : 
+					{
+						"values" : 
+						[
+							850
+						]
+					}
+				}
+			},
+			"ranges" : 
+			{
+				"temperature" : 
+				{
+					"axisNames" : 
+					[
+						"x",
+						"y",
+						"z",
+						"t"
+					],
+					"dataType" : "float",
+					"shape" : 
+					[
+						1,
+						1,
+						1,
+						1
+					],
+					"type" : "NdArray",
+					"values" : 
+					[
+						2.7
+					]
+				}
+			}
+		}
+	],
+	"domainType" : "Point",
+	"referencing" : 
+	[
+		{
+			"coordinates" : 
+			[
+				"x",
+				"y"
+			],
+			"system" : 
+			{
+				"id" : "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+				"type" : "GeographicCRS"
+			}
+		},
+		{
+			"coordinates" : 
+			[
+				"z"
+			],
+			"system" : 
+			{
+				"id" : "TODO: PressureLevel",
+				"type" : "VerticalCRS"
+			}
+		},
+		{
+			"coordinates" : 
+			[
+				"t"
+			],
+			"system" : 
+			{
+				"calendar" : "Gregorian",
+				"type" : "TemporalRS"
+			}
+		}
+	],
+	"type" : "CoverageCollection",
+	"parameters" : 
+	{
+		"temperature" : 
+		{
+			"id" : "Temperature",
+			"type" : "Parameter",
+			"description" : 
+			{
+				"fi" : "Ilman lämpötila"
+			},
+			"label" : 
+			{
+				"fi" : "Temperature"
+			},
+			"observedProperty" : 
+			{
+				"id" : "Temperature",
+				"label" : 
+				{
+					"fi" : "Temperature"
+				}
+			},
+			"unit" : 
+			{
+				"label" : 
+				{
+					"fi" : "Celsius"
+				},
+				"symbol" : 
+				{
+					"type" : "http://codes.wmo.int/common/unit/_degC",
+					"value" : "˚C"
+				}
+			}
+		}
+	}
+}

--- a/test/grid/input/grid_painepinta_area_levels.get
+++ b/test/grid/input/grid_painepinta_area_levels.get
@@ -1,0 +1,2 @@
+GET /edr/collections/ecmwf_skandinavia_painepinta.5901.2/area?coords=POLYGON((24+60,26+60,26+62,24+62,24+60))&datetime=200809091200&parameter-name=t-k HTTP/1.0
+

--- a/test/grid/output/grid_painepinta_area_levels.get
+++ b/test/grid/output/grid_painepinta_area_levels.get
@@ -1,0 +1,6596 @@
+{
+"coverages" : 
+[
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-41.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+30000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-42.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-12.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+50000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+-13.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.700001
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.799999
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.700001
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.799999
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+1.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.700001
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+70000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+0.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+4.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+2.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+2.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+85000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+2.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+7.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+6.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.4
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+92500
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+5.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.17058
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.04666
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.86692
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.01917
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.22359
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.40540
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.1
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.92870
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.37752
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.8
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.63232
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.34536
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.27797
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.76471
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.9
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.99207
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.73643
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.70462
+]
+},
+"y" : 
+{
+"values" : 
+[
+60.70380
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.6
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.33376
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.12459
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.05709
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.09589
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.77880
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.06278
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.39103
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.48502
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.5
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.12382
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.45589
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.85493
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.42230
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.2
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+24.44982
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.84600
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+12.3
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.19232
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.81644
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.7
+]
+}
+}
+},
+{
+"type" : "Coverage",
+"domain" : 
+{
+"type" : "Domain",
+"axes" : 
+{
+"t" : 
+{
+"values" : 
+[
+"2008-09-09T09:00:00Z"
+]
+},
+"x" : 
+{
+"values" : 
+[
+25.93308
+]
+},
+"y" : 
+{
+"values" : 
+[
+61.78234
+]
+},
+"z" : 
+{
+"values" : 
+[
+100000
+]
+}
+}
+},
+"ranges" : 
+{
+"t-k" : 
+{
+"axisNames" : 
+[
+"x",
+"y",
+"z",
+"t"
+],
+"dataType" : "float",
+"shape" : 
+[
+1,
+1,
+1,
+1
+],
+"type" : "NdArray",
+"values" : 
+[
+11.5
+]
+}
+}
+}
+],
+"domainType" : "Point",
+"referencing" : 
+[
+{
+"coordinates" : 
+[
+"x",
+"y"
+],
+"system" : 
+{
+"id" : "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+"type" : "GeographicCRS"
+}
+},
+{
+"coordinates" : 
+[
+"z"
+],
+"system" : 
+{
+"id" : "TODO: PRESSURE",
+"type" : "VerticalCRS"
+}
+},
+{
+"coordinates" : 
+[
+"t"
+],
+"system" : 
+{
+"calendar" : "Gregorian",
+"type" : "TemporalRS"
+}
+}
+],
+"type" : "CoverageCollection",
+"parameters" : 
+{
+"t-k" : 
+{
+"id" : "t-k",
+"type" : "Parameter",
+"description" : 
+{
+"fi" : "Temperature in Kelvins"
+},
+"label" : 
+{
+"fi" : "t-k"
+},
+"observedProperty" : 
+{
+"id" : "t-k",
+"label" : 
+{
+"fi" : "t-k"
+}
+}
+}
+}
+}


### PR DESCRIPTION
Area (and other multi coordinate) queries on a grid producer having vertical levels failed with

    [std::bad_variant_access] Unexpected index

Grid engine returns the data parameters and longitude/latitude of such a query as coordinate groups (TS::TimeSeriesGroupPtr), but the 'level' column appended by EDRQueryParams is handled as a location independent special parameter and returned as a plain time series. CoverageJson assumed all the columns to have the same type and used std::get for all of them, so the type mismatch escaped as std::bad_variant_access. Which of the formatters threw depends on the type of the first column only.

Grid engine also fetches each level of a parameter as a separate parameter, so the level of a column is known from its name only (<param>:<producer>:<geometry>:<levelid>:<level>). The data of such columns was keyed by the bare parameter name and replaced instead of merged, so even without the exception only the last level would have been left in the output, with the level value of the unrelated 'level' column.

- as_timeseries_group()/as_timeseries() adapt a column to the type the formatter needs instead of requiring it; location independent columns are handled as data of the first coordinate
- coverage collection output takes the level of a grid producer column from its name and merges the data of all the levels of a parameter, so an area query now returns one coverage per point and level, like querydata producers do
- output format is selected by checking all the columns for coordinate groups instead of the first column only
- get_level()/add_parameter() tolerate a missing or shorter level column and check_column_count() reports a column/parameter count mismatch as an exception with details instead of failing on out of range access

Added tests for an area query with levels for both a grid producer (test/grid, the failing case) and a querydata producer (test/base).